### PR TITLE
Fix Upgrade Aquatic integration

### DIFF
--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -38,8 +38,8 @@ dependencies {
     common(project(path: ":common", configuration: "namedElements")) { transitive false }
     shadowCommon(project(path: ":common", configuration: "transformProductionForge")) { transitive = false }
 
-    modCompileOnly("curse.maven:upgrade-aquatic-326895:4415517")
-    modCompileOnly("curse.maven:blueprint-382216:4749000")
+    modCompileOnly("curse.maven:upgrade-aquatic-326895:5296565")
+    modCompileOnly("curse.maven:blueprint-382216:5201927")
 
     modCompileOnly("maven.modrinth:rubidium:0.7.0a")
 }

--- a/forge/src/main/java/nl/teamdiopside/seamless/forge/mixin/FloweringRushBlockMixin.java
+++ b/forge/src/main/java/nl/teamdiopside/seamless/forge/mixin/FloweringRushBlockMixin.java
@@ -1,10 +1,10 @@
 package nl.teamdiopside.seamless.forge.mixin;
 
-import com.teamabnormals.blueprint.common.block.BlueprintTallFlowerBlock;
 import com.teamabnormals.upgrade_aquatic.common.block.FloweringRushBlock;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.TallFlowerBlock;
 import net.minecraft.world.level.block.BonemealableBlock;
 import net.minecraft.world.level.block.SimpleWaterloggedBlock;
 import net.minecraft.world.level.block.state.BlockState;
@@ -19,7 +19,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(FloweringRushBlock.class)
-public abstract class FloweringRushBlockMixin extends BlueprintTallFlowerBlock implements SimpleWaterloggedBlock, BonemealableBlock {
+public abstract class FloweringRushBlockMixin extends TallFlowerBlock implements SimpleWaterloggedBlock, BonemealableBlock {
 
     @Shadow @Final private static VoxelShape SHAPE;
 

--- a/forge/src/main/resources/resourcepacks/default_seamless/assets/upgrade_aquatic/seamless_rules/double_high_lower.json
+++ b/forge/src/main/resources/resourcepacks/default_seamless/assets/upgrade_aquatic/seamless_rules/double_high_lower.json
@@ -1,5 +1,5 @@
 {
-  "blocks": ["upgrade_aquatic:tall_blue_pickerelweed", "upgrade_aquatic:tall_purple_pickerelweed", "upgrade_aquatic:tall_beachgrass"],
+  "blocks": ["upgrade_aquatic:tall_pickerelweed", "upgrade_aquatic:tall_beachgrass"],
   "blockstates": {
     "half": ["lower"]
   },

--- a/forge/src/main/resources/resourcepacks/default_seamless/assets/upgrade_aquatic/seamless_rules/double_high_upper.json
+++ b/forge/src/main/resources/resourcepacks/default_seamless/assets/upgrade_aquatic/seamless_rules/double_high_upper.json
@@ -1,5 +1,5 @@
 {
-  "blocks": ["upgrade_aquatic:tall_blue_pickerelweed", "upgrade_aquatic:tall_purple_pickerelweed", "upgrade_aquatic:tall_beachgrass"],
+  "blocks": ["upgrade_aquatic:tall_pickerelweed", "upgrade_aquatic:tall_beachgrass"],
   "blockstates": {
     "half": ["upper"]
   },


### PR DESCRIPTION
fixes #32 as well as following errors

```
[20:46:02] [Render thread/ERROR] [Seamless/]: Block "upgrade_aquatic:tall_purple_pickerelweed" from upgrade_aquatic:double_high_lower does not exist!
[20:46:02] [Render thread/ERROR] [Seamless/]: Block "upgrade_aquatic:tall_blue_pickerelweed" from upgrade_aquatic:double_high_lower does not exist!
[20:46:02] [Render thread/ERROR] [Seamless/]: Block "upgrade_aquatic:tall_purple_pickerelweed" from upgrade_aquatic:double_high_upper does not exist!
[20:46:02] [Render thread/ERROR] [Seamless/]: Block "upgrade_aquatic:tall_blue_pickerelweed" from upgrade_aquatic:double_high_upper does not exist!
```