### PR TITLE
Fix Environmental integration

### DIFF
--- a/forge/src/main/resources/resourcepacks/default_seamless/assets/environmental/seamless_rules/cattail.json
+++ b/forge/src/main/resources/resourcepacks/default_seamless/assets/environmental/seamless_rules/cattail.json
@@ -1,0 +1,5 @@
+{
+  "blocks": ["environmental:cattail"],
+  "directions": ["down"],
+  "connecting_blocks": ["environmental:cattail_stalk"]
+}

--- a/forge/src/main/resources/resourcepacks/default_seamless/assets/environmental/seamless_rules/cattail_stalk.json
+++ b/forge/src/main/resources/resourcepacks/default_seamless/assets/environmental/seamless_rules/cattail_stalk.json
@@ -1,0 +1,5 @@
+{
+  "blocks": ["environmental:cattail_stalk"],
+  "directions": ["up", "down"],
+  "connecting_blocks": ["/same", "environmental:cattail"]
+}

--- a/forge/src/main/resources/resourcepacks/default_seamless/assets/environmental/seamless_rules/double_high_lower.json
+++ b/forge/src/main/resources/resourcepacks/default_seamless/assets/environmental/seamless_rules/double_high_lower.json
@@ -1,5 +1,5 @@
 {
-  "blocks": ["environmental:tall_cattail", "environmental:tall_dead_bush", "environmental:giant_tall_grass"],
+  "blocks": ["environmental:giant_tall_grass"],
   "blockstates": {
     "half": ["lower"]
   },

--- a/forge/src/main/resources/resourcepacks/default_seamless/assets/environmental/seamless_rules/double_high_upper.json
+++ b/forge/src/main/resources/resourcepacks/default_seamless/assets/environmental/seamless_rules/double_high_upper.json
@@ -1,5 +1,5 @@
 {
-  "blocks": ["environmental:tall_cattail", "environmental:tall_dead_bush", "environmental:giant_tall_grass"],
+  "blocks": ["environmental:giant_tall_grass"],
   "blockstates": {
     "half": ["upper"]
   },

--- a/forge/src/main/resources/resourcepacks/default_seamless/assets/environmental/seamless_rules/lily_pad_center.json
+++ b/forge/src/main/resources/resourcepacks/default_seamless/assets/environmental/seamless_rules/lily_pad_center.json
@@ -1,0 +1,8 @@
+{
+  "blocks": ["environmental:giant_lily_pad"],
+  "blockstates": {
+    "position": ["center"]
+  },
+  "directions": ["north", "east", "south", "west"],
+  "connecting_blocks": ["/same"]
+}

--- a/forge/src/main/resources/resourcepacks/default_seamless/assets/environmental/seamless_rules/lily_pad_east.json
+++ b/forge/src/main/resources/resourcepacks/default_seamless/assets/environmental/seamless_rules/lily_pad_east.json
@@ -1,7 +1,7 @@
 {
   "blocks": ["environmental:giant_lily_pad"],
   "blockstates": {
-    "position": ["northeast"]
+    "position": ["east"]
   },
   "directions": ["north", "south", "west"],
   "connecting_blocks": ["/same"]


### PR DESCRIPTION
fixes #30 as well as following errors

```
[22:20:41] [Render thread/ERROR] [Seamless/]: Block "environmental:tall_cattail" from environmental:double_high_lower does not exist!
[22:20:41] [Render thread/ERROR] [Seamless/]: Block "environmental:tall_dead_bush" from environmental:double_high_lower does not exist!
[22:20:41] [Render thread/ERROR] [Seamless/]: Block "environmental:tall_cattail" from environmental:double_high_upper does not exist!
[22:20:41] [Render thread/ERROR] [Seamless/]: Block "environmental:tall_dead_bush" from environmental:double_high_upper does not exist!
```